### PR TITLE
Set MinVer tag prefix

### DIFF
--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -9,6 +9,7 @@
   <!-- Setup global MSBuild variables -->
   <PropertyGroup>
     <EnlistmentRoot>$(MSBuildThisFileDirectory.TrimEnd({'\\'}))\..</EnlistmentRoot>
+	<MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
   <!-- Begin common properties for all projects -->


### PR DESCRIPTION
Set the MinVer tag prefix, to make sure the version numbers are inline with the release tags.