### PR TITLE
Remove transitive dependencies

### DIFF
--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -17,19 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.10.0" />
-    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
 	<PackageId>Trill.Provider.NET</PackageId>
+	<description>Trill is a high-performance one-pass in-memory streaming analytics engine</description>
+    <PackageTags>Streaming Temporal Data</PackageTags>
     <PackageProjectUrl>https://github.com/sparklinglogic/Trill</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/sparklinglogic/Trill/releases</PackageReleaseNotes>
 	<PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
     <PackageId>Trill.NET</PackageId>
+	<description>Trill is a high-performance one-pass in-memory streaming analytics engine</description>
+    <PackageTags>Streaming Temporal Data</PackageTags>
     <PackageProjectUrl>https://github.com/sparklinglogic/Trill</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/sparklinglogic/Trill/releases</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -17,13 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.10.0" />
-    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Expressions" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>
 

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -6,11 +6,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/Sources/Test/TrillPerf/PerformanceTesting.csproj
+++ b/Sources/Test/TrillPerf/PerformanceTesting.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
     <PackageReference Include="System.Reactive" Version="6.0.1" />
     <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />


### PR DESCRIPTION
Remove explicit package references to packages that are already part of transitive dependencies.
This will make it easier to maintain and keep up-to-date with package versions. In addition it will reduce the number of dependencies required for the package.