### PR TITLE
Migrate from .netstandard 2.0 to .net 10.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         filter: tree:0
     - uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.0.x'
+        dotnet-version: '10.0.x'
 
     - run: dotnet --info
     

--- a/Sources/.editorconfig
+++ b/Sources/.editorconfig
@@ -51,3 +51,12 @@ csharp_new_line_before_finally = true
 csharp_indent_case_contents = true
 csharp_indent_switch_labels = true
 csharp_preserve_single_line_statements = false
+
+# test analyzer
+[*.{cs,vb}]
+dotnet_diagnostic.MSTEST0001.severity = none
+dotnet_diagnostic.MSTEST0023.severity = none
+dotnet_diagnostic.MSTEST0025.severity = none
+dotnet_diagnostic.MSTEST0030.severity = none
+dotnet_diagnostic.MSTEST0032.severity = none
+dotnet_diagnostic.MSTEST0037.severity = none

--- a/Sources/Core/Directory.Build.props
+++ b/Sources/Core/Directory.Build.props
@@ -3,13 +3,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <!-- Code Analysis -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' And '$(Configuration)' == 'Debug'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net10.0' And '$(Configuration)' == 'Debug'">
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <!-- Do not set RunCodeAnalysis*, as this is incompatible with netstandard2.0. Analyzers run by default whenever included. -->
     <CodeAnalysisRuleSet>$(EnlistmentRoot)\Sources\Microsoft.StreamProcessing.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing.Provider/Microsoft.StreamProcessing.Provider.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
 	<PackageId>Trill.Provider.NET</PackageId>
 	<description>Trill is a high-performance one-pass in-memory streaming analytics engine</description>
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
+++ b/Sources/Core/Microsoft.StreamProcessing/Microsoft.StreamProcessing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Platforms>x64;AnyCPU</Platforms>
     <PackageId>Trill.NET</PackageId>
 	<description>Trill is a high-performance one-pass in-memory streaming analytics engine</description>
@@ -17,8 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="4.10.0" />
-    <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Sources/Core/Microsoft.StreamProcessing/QueryContainer.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/QueryContainer.cs
@@ -202,11 +202,11 @@ namespace Microsoft.StreamProcessing
                 if (inputStream != null)
                 {
                     byte[] buffer = new byte[sizeof(int)];
-                    inputStream.Read(buffer, 0, sizeof(int));
+                    var len = inputStream.Read(buffer, 0, sizeof(int));
                     int major = BitConverter.ToInt32(buffer, 0);
-                    inputStream.Read(buffer, 0, sizeof(int));
+                    len = inputStream.Read(buffer, 0, sizeof(int));
                     int minor = BitConverter.ToInt32(buffer, 0);
-                    inputStream.Read(buffer, 0, sizeof(int));
+                    len = inputStream.Read(buffer, 0, sizeof(int));
                     int revision = BitConverter.ToInt32(buffer, 0);
 
                     if (major != CheckpointVersionMajor || minor != CheckpointVersionMinor || revision != CheckpointVersionRevision)

--- a/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
+++ b/Sources/Core/Microsoft.StreamProcessing/StreamProcessing.nuspec
@@ -13,23 +13,15 @@
     <language>en-US</language>
     <tags>Streaming Temporal Data</tags>
     <dependencies>
-      <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CodeAnalysis.Scripting" version="3.1.0" />
-        <dependency id="Microsoft.CSharp" version="4.5.0" />
-        <dependency id="NETStandard.Library" version="2.0.0" />
-        <dependency id="System.Diagnostics.Contracts" version="4.3.0" />
-        <dependency id="System.Diagnostics.Process" version="4.3.0" />
-        <dependency id="System.Linq.Expressions" version="4.3.0" />
-        <dependency id="System.Runtime.Loader" version="4.3.0" />
-        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
-        <dependency id="System.Threading.Thread" version="4.3.0" />
+      <group targetFramework="net10.0">
+        <dependency id="Microsoft.CodeAnalysis.Scripting" version="5.0.0" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="..\..\..\bin\AnyCPU\$configuration$\netstandard2.0\Microsoft.StreamProcessing.deps.json" target="lib\netstandard2.0" />
-    <file src="..\..\..\bin\AnyCPU\$configuration$\netstandard2.0\Microsoft.StreamProcessing.dll" target="lib\netstandard2.0" />
-    <file src="..\..\..\bin\AnyCPU\$configuration$\netstandard2.0\Microsoft.StreamProcessing.pdb" target="lib\netstandard2.0" />
-    <file src="..\..\..\bin\AnyCPU\$configuration$\netstandard2.0\Microsoft.StreamProcessing.xml" target="lib\netstandard2.0" />
+    <file src="..\..\..\bin\AnyCPU\$configuration$\net10.0\Microsoft.StreamProcessing.deps.json" target="lib\net10.0" />
+    <file src="..\..\..\bin\AnyCPU\$configuration$\net10.0\Microsoft.StreamProcessing.dll" target="lib\net10.0" />
+    <file src="..\..\..\bin\AnyCPU\$configuration$\net10.0\Microsoft.StreamProcessing.pdb" target="lib\net10.0" />
+    <file src="..\..\..\bin\AnyCPU\$configuration$\net10.0\Microsoft.StreamProcessing.xml" target="lib\net10.0" />
   </files>
 </package>

--- a/Sources/Core/Microsoft.StreamProcessing/Utilities/Native32.cs
+++ b/Sources/Core/Microsoft.StreamProcessing/Utilities/Native32.cs
@@ -75,7 +75,8 @@ namespace Microsoft.StreamProcessing
                 if (utid == pt.Id)
                 {
                     long AffinityMask = 1 << processor;
-                    pt.ProcessorAffinity = (IntPtr)(AffinityMask); // Set affinity for this
+                    if (OperatingSystem.IsWindows())
+                        pt.ProcessorAffinity = (IntPtr)(AffinityMask); // Set affinity for this
                 }
             }
         }

--- a/Sources/Directory.Build.props
+++ b/Sources/Directory.Build.props
@@ -3,7 +3,7 @@
   <!-- Global include of the version file to avoid per-project link inclusion. -->
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CommonAssemblyInfo.cs" />
-	<PackageReference Include="MinVer" Version="5.0.0" PrivateAssets="All" />
+	<PackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <!-- Setup global MSBuild variables -->

--- a/Sources/Test/SimpleTesting/AdHocTests.cs
+++ b/Sources/Test/SimpleTesting/AdHocTests.cs
@@ -44,7 +44,7 @@ namespace SimpleTesting
                 .ToObservable()
                 .ToStreamable(DisorderPolicy.Throw(), FlushPolicy.FlushOnPunctuation, PeriodicPunctuationPolicy.None(), OnCompletedPolicy.None);
 
-            var q2 = q1.Select(x => string.Join(",", x.A, x.B, x.C, x.D, x.E));
+            var q2 = q1.Select(x => string.Join(",", new object[] { x.A, x.B, x.C, x.D, x.E }));
 
             int count = 0;
             q2.ToStreamEventObservable().ForEachAsync(x => count++).Wait();
@@ -67,7 +67,7 @@ namespace SimpleTesting
                 .ToObservable()
                 .ToStreamable(DisorderPolicy.Throw(), FlushPolicy.FlushOnPunctuation, PeriodicPunctuationPolicy.None(), OnCompletedPolicy.None);
 
-            var q2 = q1.Select(x => string.Join(",", x.A, x.B, x.C, x.D, x.E));
+            var q2 = q1.Select(x => string.Join(",", new object[] { x.A, x.B, x.C, x.D, x.E }));
 
             int count = 0;
             q2.ToStreamEventObservable().ForEachAsync(x => count++).Wait();
@@ -1271,7 +1271,7 @@ namespace SimpleTesting
         { }
 
         [TestMethod, TestCategory("Gated")]
-        public async Task DisposeTest1()
+        public void DisposeTest1()
         {
             var cancelTokenSource = new CancellationTokenSource();
             var inputSubject = new Subject<int>();
@@ -1300,15 +1300,15 @@ namespace SimpleTesting
             inputTask.Start();
 
             // Wait until we have at least one output data event.
-            await semaphore.WaitAsync();
+            semaphore.Wait();
 
             // Dispose the subscription.
             subscription.Dispose();
 
             // Keep the input feed going, before cancel. This should behave properly if the subscription is disposed of properly.
-            await Task.Delay(200);
+            Task.Delay(200).ConfigureAwait(true).GetAwaiter().GetResult();
             cancelTokenSource.Cancel();
-            await inputTask;
+            inputTask.ConfigureAwait(true).GetAwaiter().GetResult();
 
             // Make sure we really got an output data event.
             Assert.IsTrue(lastSeenSubscription > 0);

--- a/Sources/Test/SimpleTesting/SimpleTesting.csproj
+++ b/Sources/Test/SimpleTesting/SimpleTesting.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive.Linq" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <!--

--- a/Sources/Test/TrillPerf/PerformanceTesting.csproj
+++ b/Sources/Test/TrillPerf/PerformanceTesting.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="3.4.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.4.3" />
-    <PackageReference Include="System.Reactive" Version="6.0.1" />
-    <PackageReference Include="System.Reactive.Linq" Version="6.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.0.2" />
+    <PackageReference Include="System.Reactive" Version="6.1.0" />
+    <PackageReference Include="System.Reactive.Linq" Version="6.1.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
- Migrate to .NET 10
  NetStandard has lots of old transitive dependencies and is no longer developed by Microsoft.
- Update 3rd party dependencies
- Fix test suite
  The async DisposeTest1 fails, due to the fact that the dispose of the ConfigModifier is done on a different thread and therefore can't release the lock it created in the setup. By making the test sync, this problem is avoided and the test will run properly.